### PR TITLE
use session storage as a fallback to store the budgetId  #21

### DIFF
--- a/client/src/reducers/SiteReducer.tsx
+++ b/client/src/reducers/SiteReducer.tsx
@@ -3,8 +3,13 @@ import { IReducerAction } from '../contracts/reducer-action.interface';
 import { ISiteState } from '../contracts/site-state.interface';
 
 function siteState(state: ISiteState = {}, action: IReducerAction) {
+  const sessionStorageBudgetId = sessionStorage.getItem('budgetId');
+  if (sessionStorageBudgetId) {
+    state.budgetId = sessionStorageBudgetId as string;
+  }
   switch (action.type) {
     case SiteActions.UPDATE_SELECTED_BUDGET:
+      sessionStorage.setItem('budgetId', action.payload.budgetId);
       return Object.assign({}, state, { budgetId: action.payload.budgetId });
     default:
       return state;


### PR DESCRIPTION
Not the ideal scenario, might still revisit this one day, but for now it's good enough to allow the page to hot reload without navigating me back.